### PR TITLE
Fix variable name in FASTQ to FASTA converter.

### DIFF
--- a/bin/fastq-to-fasta
+++ b/bin/fastq-to-fasta
@@ -23,7 +23,7 @@ def main():
     with open(args.fastq) as input_handle, open(args.fasta, "w") as output_handle:
         records = SeqIO.parse(input_handle, "fastq")
         for record in records:
-            handle.write(record.format("fasta"))
+            output_handle.write(record.format("fasta"))
 
     output_handle.close()
 


### PR DESCRIPTION
Dear @audy,

Thank you very much for sharing these utility scripts!

Just used the FASTQ to FASTA converter and had to fix `NameError: name 'handle' is not defined` :)